### PR TITLE
Sync Device IDs with the C SDK's ins_packets.h.

### DIFF
--- a/anpp_packets/an_packet_3.py
+++ b/anpp_packets/an_packet_3.py
@@ -47,12 +47,20 @@ class DeviceID(Enum):
     air_data_unit = 13
     spatial_fog_dual = 16
     motus = 17
-    gnss_compass = 18
+    gnss_compass = 19
     certus = 26
     aries = 27
     boreas_d90 = 28
-    boreas_d90_fpga = 35
-    boreas_coil = 36
+    boreas_90_fpga = 35
+    boreas_90_coil = 36
+    boreas_70_coil = 40
+    boreas_d70 = 41
+    boreas_70_fpga = 42
+    boreas_a90 = 43
+    boreas_a70 = 44
+    certus_mini_a = 49
+    certus_mini_n = 50
+    certus_mini_d = 51
 
 
 @dataclass()


### PR DESCRIPTION
CertusMiniDSDK_v7.3/C/Dynamic/ins_packets.h, lines 1-28, 199-225:
```
/******************************************************************************/
/*                                                                            */
/*                Advanced Navigation Packet Protocol Library                 */
/*             C Language Dynamic Certus Mini D SDK, Version 7.3              */
/*                    Copyright 2024, Advanced Navigation                     */
/*                                                                            */
/******************************************************************************/
/*
 * Copyright (C) 2024 Advanced Navigation
 *
 * Permission is hereby granted, free of charge, to any person obtaining
 * a copy of this software and associated documentation files (the "Software"),
 * to deal in the Software without restriction, including without limitation
 * the rights to use, copy, modify, merge, publish, distribute, sublicense,
 * and/or sell copies of the Software, and to permit persons to whom the
 * Software is furnished to do so, subject to the following conditions:
 *
 * The above copyright notice and this permission notice shall be included
 * in all copies or substantial portions of the Software.
 *
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
 * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 * DEALINGS IN THE SOFTWARE.
 */
 ...
typedef enum
{
	device_id_spatial = 1,
	device_id_orientus = 3,
	device_id_spatial_fog,
	device_id_spatial_dual,
	device_id_obdii_odometer = 10,
	device_id_orientus_v3,
	device_id_ilu,
	device_id_air_data_unit,
	device_id_spatial_fog_dual = 16,
	device_id_motus,
	device_id_gnss_compass = 19,
	device_id_certus = 26,
	device_id_aries,
	device_id_boreas_d90,
	device_id_boreas_90_fpga = 35,
	device_id_boreas_90_coil,
	device_id_boreas_70_coil = 40,
	device_id_boreas_d70,
	device_id_boreas_70_fpga,
	device_id_boreas_a90,
	device_id_boreas_a70,
	device_id_certus_mini_a = 49,
	device_id_certus_mini_n,
	device_id_certus_mini_d
} device_id_e;
```